### PR TITLE
Update to 0.18

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,11 +32,11 @@ environment:
 
     - TARGET_ARCH: x86
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -47,7 +47,7 @@ platform:
 install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
-        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
         ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "morepath" %}
-{% set version = "0.17" %}
-{% set sha256 = "e2c3c6f545ce50f649f5a978a462d7f14a4fbab03fc8d79ffcb8e557057f6bdc" %}
+{% set version = "0.18" %}
+{% set sha256 = "41a779093fb48583ef071be72a6895ea092fb53513d439e86c826455d93f65a2" %}
 
 package:
   name: {{ name|lower }}
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script:
+    - python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:


### PR DESCRIPTION
0.18 (2017-03-17)

New: The load` API, which allows you to define how incoming JSON (through a POST, PUT or PATH request) will be converted to a Python object and how it will be validated. This feature lets you plug in external serialization and validation libraries, such as Marshmallow, Colander, Cerberus, Jsonschema or Voluptuous.

Removed: morepath.body_model_predicate is removed from the Morepath API together with the morepath.App.load_json directive and the morepath.request.body_obj property. If you use the load_json directive, this functionality has been moved to a separate more.body_model package. Use this package instead by subclassing your App from more.body_model.BodyModelApp.

Uploading huge files lead to excessive memory consumption as the whole body was consumed for no good reason. This is now fixed.

See #504

Fixes link prefix not applying to mounted applications.

See ‘#516’